### PR TITLE
Add a way to choose the minimum score for a group 

### DIFF
--- a/cmd/validator/main.go
+++ b/cmd/validator/main.go
@@ -38,7 +38,7 @@ func main() {
 	defer contestant.Close()
 
 	validator := &common.ValidatorSettings{
-		Name:      *validatorName,
+		Name:      common.ValidatorName(*validatorName),
 		Tolerance: tolerance,
 	}
 	score, mismatch, err := runner.CalculateScore(

--- a/common/literalinput.go
+++ b/common/literalinput.go
@@ -114,7 +114,7 @@ type LiteralCustomValidatorSettings struct {
 // CustomValidator must be provided. If "token-numeric" is chosen, Tolerance
 // must contain a numeric tolerance (typically a small number).
 type LiteralValidatorSettings struct {
-	Name            string                          `json:"name"`
+	Name            ValidatorName                   `json:"name"`
 	Tolerance       *float64                        `json:"tolerance,omitempty"`
 	CustomValidator *LiteralCustomValidatorSettings `json:"custom_validator,omitempty"`
 }
@@ -140,7 +140,7 @@ var (
 	}
 
 	DefaultLiteralValidatorSettings = LiteralValidatorSettings{
-		Name: "token-caseless",
+		Name: ValidatorNameTokenCaseless,
 	}
 
 	DefaultValidatorTolerance = 1e-6
@@ -248,7 +248,7 @@ func NewLiteralInputFactory(
 		validator = &DefaultLiteralValidatorSettings
 	}
 	switch validator.Name {
-	case "custom":
+	case ValidatorNameCustom:
 		if validator.CustomValidator == nil {
 			return nil, errors.New("custom validator empty")
 		}
@@ -263,9 +263,9 @@ func NewLiteralInputFactory(
 			limits := DefaultValidatorLimits
 			validator.CustomValidator.Limits = &limits
 		}
-	case "token", "token-caseless", "literal":
+	case ValidatorNameToken, ValidatorNameTokenCaseless, ValidatorNameLiteral:
 		settings.Validator.Name = validator.Name
-	case "token-numeric":
+	case ValidatorNameTokenNumeric:
 		settings.Validator.Name = validator.Name
 		if validator.Tolerance != nil {
 			settings.Validator.Tolerance = validator.Tolerance

--- a/common/literalinput.go
+++ b/common/literalinput.go
@@ -114,9 +114,10 @@ type LiteralCustomValidatorSettings struct {
 // CustomValidator must be provided. If "token-numeric" is chosen, Tolerance
 // must contain a numeric tolerance (typically a small number).
 type LiteralValidatorSettings struct {
-	Name            ValidatorName                   `json:"name"`
-	Tolerance       *float64                        `json:"tolerance,omitempty"`
-	CustomValidator *LiteralCustomValidatorSettings `json:"custom_validator,omitempty"`
+	Name             ValidatorName                   `json:"name"`
+	GroupScorePolicy GroupScorePolicy                `json:"groupScorePolicy,omitempty"`
+	Tolerance        *float64                        `json:"tolerance,omitempty"`
+	CustomValidator  *LiteralCustomValidatorSettings `json:"custom_validator,omitempty"`
 }
 
 // LiteralInteractiveSettings stores the settings for a problem that uses
@@ -247,6 +248,7 @@ func NewLiteralInputFactory(
 	if validator == nil {
 		validator = &DefaultLiteralValidatorSettings
 	}
+	settings.Validator.GroupScorePolicy = validator.GroupScorePolicy
 	switch validator.Name {
 	case ValidatorNameCustom:
 		if validator.CustomValidator == nil {

--- a/common/literalinput_test.go
+++ b/common/literalinput_test.go
@@ -24,7 +24,7 @@ func TestLiteralInput(t *testing.T) {
 				"1": {Input: "2 3", ExpectedOutput: "5", Weight: big.NewRat(1, 1)},
 			},
 			Validator: &LiteralValidatorSettings{
-				Name: "token-numeric",
+				Name: ValidatorNameTokenNumeric,
 			},
 		},
 		dirname,

--- a/common/problemsettings.go
+++ b/common/problemsettings.go
@@ -25,10 +25,33 @@ type LimitsSettings struct {
 	TimeLimit            base.Duration
 }
 
+// ValidatorName is a valid name for a validator.
+type ValidatorName string
+
+const (
+	// ValidatorNameToken compares whitespace-separated tokens.
+	ValidatorNameToken ValidatorName = "token"
+	// ValidatorNameTokenNumeric compares numeric tokens only, ignoring anything
+	// that is not numeric.
+	ValidatorNameTokenNumeric ValidatorName = "token-numeric"
+	// ValidatorNameTokenCaseless compares whitespace-separated tokens, ignoring
+	// the case.
+	ValidatorNameTokenCaseless ValidatorName = "token-caseless"
+	// ValidatorNameLiteral parses the output as a floating point number in the
+	// [0.0, 1.0] range and assigns it as the score. This is typically only used
+	// for interactive problems.
+	ValidatorNameLiteral ValidatorName = "literal"
+	// ValidatorNameCustom runs a custom validator that is responsible for
+	// reading the expected and contestant's outputs and printing a single
+	// floating point number in the [0.0, 1.0] range to stdout. The score will be
+	// that number.
+	ValidatorNameCustom ValidatorName = "custom"
+)
+
 // ValidatorSettings represents the options used to validate outputs.
 type ValidatorSettings struct {
 	Lang      *string         `json:"Lang,omitempty"`
-	Name      string          `json:"Name"`
+	Name      ValidatorName   `json:"Name"`
 	Tolerance *float64        `json:"Tolerance,omitempty"`
 	Limits    *LimitsSettings `json:"Limits,omitempty"`
 }

--- a/common/problemsettings.go
+++ b/common/problemsettings.go
@@ -48,12 +48,30 @@ const (
 	ValidatorNameCustom ValidatorName = "custom"
 )
 
+// GroupScorePolicy is the policy that will be used to assign scores in a group.
+type GroupScorePolicy string
+
+const (
+	// GroupScorePolicySumIfNotZero assigns the sum of all the individual cases'
+	// scores if they are all non-zero. This is the default, and will be used if
+	// the policy is not selected.
+	GroupScorePolicySumIfNotZero GroupScorePolicy = "sum-if-not-zero"
+
+	// GroupScorePolicyDefault is an alias of GroupScorePolicySumIfNotZero.
+	GroupScorePolicyDefault GroupScorePolicy = ""
+
+	// GroupScorePolicyMin assigns the minimum of all the individual cases'
+	// scores multiplied by the weight of the group.
+	GroupScorePolicyMin GroupScorePolicy = "min"
+)
+
 // ValidatorSettings represents the options used to validate outputs.
 type ValidatorSettings struct {
-	Lang      *string         `json:"Lang,omitempty"`
-	Name      ValidatorName   `json:"Name"`
-	Tolerance *float64        `json:"Tolerance,omitempty"`
-	Limits    *LimitsSettings `json:"Limits,omitempty"`
+	Lang             *string          `json:"Lang,omitempty"`
+	Name             ValidatorName    `json:"Name"`
+	Tolerance        *float64         `json:"Tolerance,omitempty"`
+	Limits           *LimitsSettings  `json:"Limits,omitempty"`
+	GroupScorePolicy GroupScorePolicy `json:"GroupScorePolicy,omitempty"`
 }
 
 // InteractiveInterface represents the metadata needed to compile and run

--- a/grader/input_test.go
+++ b/grader/input_test.go
@@ -106,7 +106,7 @@ func TestPreloadInputs(t *testing.T) {
 					"1": {Input: "2 3", ExpectedOutput: "5", Weight: big.NewRat(1, 1)},
 				},
 				Validator: &common.LiteralValidatorSettings{
-					Name: "token-numeric",
+					Name: common.ValidatorNameTokenNumeric,
 				},
 			},
 			ctx.Config.Grader.RuntimePath,

--- a/grader/queue_test.go
+++ b/grader/queue_test.go
@@ -20,7 +20,7 @@ func addRun(
 				"1": {Input: "2 3", ExpectedOutput: "5", Weight: big.NewRat(1, 1)},
 			},
 			Validator: &common.LiteralValidatorSettings{
-				Name: "token-numeric",
+				Name: common.ValidatorNameTokenNumeric,
 			},
 		},
 		ctx.Config.Grader.RuntimePath,

--- a/runner/ci/ci.go
+++ b/runner/ci/ci.go
@@ -506,7 +506,7 @@ func NewRunConfig(files common.ProblemFiles, generateOutputFiles bool) (*RunConf
 		Name:      problemSettings.Validator.Name,
 		Tolerance: problemSettings.Validator.Tolerance,
 	}
-	if problemSettings.Validator.Name == "custom" {
+	if problemSettings.Validator.Name == common.ValidatorNameCustom {
 		if problemSettings.Validator.Lang == nil {
 			var validators []string
 			for _, filename := range files.Files() {
@@ -631,7 +631,7 @@ func NewRunConfig(files common.ProblemFiles, generateOutputFiles bool) (*RunConf
 			Input: &common.LiteralInput{
 				Cases: config.Input.Cases,
 				Validator: &common.LiteralValidatorSettings{
-					Name: "custom",
+					Name: common.ValidatorNameCustom,
 					CustomValidator: &common.LiteralCustomValidatorSettings{
 						Language: language,
 					},

--- a/runner/ci/ci_test.go
+++ b/runner/ci/ci_test.go
@@ -404,7 +404,7 @@ func TestNewRunConfig(t *testing.T) {
 						Input: &common.LiteralInput{
 							Cases: map[string]*common.LiteralCaseSettings{},
 							Validator: &common.LiteralValidatorSettings{
-								Name: "custom",
+								Name: common.ValidatorNameCustom,
 								CustomValidator: &common.LiteralCustomValidatorSettings{
 									Source:   "print(3)",
 									Language: "py",

--- a/runner/input_test.go
+++ b/runner/input_test.go
@@ -146,7 +146,7 @@ func TestPreloadInputs(t *testing.T) {
 					"1": {Input: "2 3", ExpectedOutput: "5", Weight: big.NewRat(1, 1)},
 				},
 				Validator: &common.LiteralValidatorSettings{
-					Name: "token-numeric",
+					Name: common.ValidatorNameTokenNumeric,
 				},
 			},
 			ctx.Config.Runner.RuntimePath,

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -796,7 +796,7 @@ func Grade(
 
 	validatorBinPath := path.Join(runRoot, "validator", "bin")
 	regularBinaryCount := len(binaries)
-	if settings.Validator.Name == "custom" {
+	if settings.Validator.Name == common.ValidatorNameCustom {
 		if err := os.MkdirAll(validatorBinPath, 0755); err != nil {
 			return runResult, err
 		}
@@ -1152,7 +1152,7 @@ func Grade(
 				contestantPath := path.Join(
 					runRoot, fmt.Sprintf("%s.out", caseData.Name),
 				)
-				if settings.Validator.Name == "custom" {
+				if settings.Validator.Name == common.ValidatorNameCustom {
 					originalInputFile := path.Join(
 						input.Path(),
 						"cases",
@@ -1226,7 +1226,7 @@ func Grade(
 				expectedPath := path.Join(
 					input.Path(), "cases", fmt.Sprintf("%s.out", caseData.Name),
 				)
-				if settings.Validator.Name == "custom" {
+				if settings.Validator.Name == common.ValidatorNameCustom {
 					// No need to open the actual file. It might not even exist.
 					expectedPath = "/dev/null"
 				}

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -182,7 +182,7 @@ func runGraderTests(t *testing.T, wrapper sandboxWrapper) {
 				"1.1": {Input: "2 3", ExpectedOutput: "5", Weight: big.NewRat(2, 1)},
 			},
 			Validator: &common.LiteralValidatorSettings{
-				Name: "token-numeric",
+				Name: common.ValidatorNameTokenNumeric,
 			},
 			Limits: &common.LimitsSettings{
 				TimeLimit:            base.Duration(time.Second),
@@ -615,7 +615,7 @@ func TestGradeLowMemOmegajail(t *testing.T) {
 				"1.1": {Input: "2 3", ExpectedOutput: "5", Weight: big.NewRat(2, 1)},
 			},
 			Validator: &common.LiteralValidatorSettings{
-				Name: "token-numeric",
+				Name: common.ValidatorNameTokenNumeric,
 			},
 			Limits: &common.LimitsSettings{
 				TimeLimit:            common.DefaultLiteralLimitSettings.TimeLimit,
@@ -775,7 +775,7 @@ func runKarelGraderTests(t *testing.T, wrapper sandboxWrapper) {
 </ejecucion>`, ExpectedOutput: expectedOutput, Weight: big.NewRat(1, 1)},
 			},
 			Validator: &common.LiteralValidatorSettings{
-				Name: "token-numeric",
+				Name: common.ValidatorNameTokenNumeric,
 			},
 		},
 		ctx.Config.Runner.RuntimePath,
@@ -885,7 +885,7 @@ func TestLibinteractive(t *testing.T) {
 				"1": {Input: "2 3", ExpectedOutput: "5", Weight: big.NewRat(1, 1)},
 			},
 			Validator: &common.LiteralValidatorSettings{
-				Name: "token-numeric",
+				Name: common.ValidatorNameTokenNumeric,
 			},
 			Interactive: &common.LiteralInteractiveSettings{
 				IDLSource: `

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -597,6 +597,156 @@ func TestGrade(t *testing.T) {
 	}
 }
 
+func TestGradeGroupScorePolicyMin(t *testing.T) {
+	for name, wrapper := range map[string]sandboxWrapper{
+		"fake":      &fakeSandboxWrapper{},
+		"omegajail": &omegajailSandboxWrapper{omegajail: getSandbox()},
+	} {
+		wrapper := wrapper
+		t.Run(name, func(t *testing.T) {
+			if testing.Short() && wrapper.name() == "OmegajailSandbox" {
+				t.Skip("skipping test in short mode.")
+			}
+			if !wrapper.supported() {
+				t.Skip(fmt.Sprintf("%s not supported", wrapper.name()))
+			}
+
+			ctx, err := newRunnerContext(t)
+			if err != nil {
+				t.Fatalf("RunnerContext creation failed with %q", err)
+			}
+			defer ctx.Close()
+			if !ctx.Config.Runner.PreserveFiles {
+				defer os.RemoveAll(ctx.Config.Runner.RuntimePath)
+			}
+
+			inputManager := common.NewInputManager(ctx)
+			AplusB, err := common.NewLiteralInputFactory(
+				&common.LiteralInput{
+					Cases: map[string]*common.LiteralCaseSettings{
+						"0":   {Input: "1 2", ExpectedOutput: "3", Weight: big.NewRat(1, 1)},
+						"1.0": {Input: "1 2", ExpectedOutput: "3", Weight: big.NewRat(1, 1)},
+						"1.1": {Input: "2 3", ExpectedOutput: "5", Weight: big.NewRat(2, 1)},
+					},
+					Validator: &common.LiteralValidatorSettings{
+						Name:             common.ValidatorNameCustom,
+						GroupScorePolicy: common.GroupScorePolicyMin,
+						CustomValidator: &common.LiteralCustomValidatorSettings{
+							Source: `#!/usr/bin/python3
+
+def _main() -> None:
+  with open('data.in', 'r') as f:
+    expected = float(f.read().strip())
+  got = float(input().strip())
+  print(f'{1 - abs(got - expected) / expected}')
+
+if __name__ == '__main__':
+  _main()
+`,
+							Language: "python3",
+						},
+					},
+					Limits: &common.LimitsSettings{
+						TimeLimit:            base.Duration(time.Second),
+						MemoryLimit:          64 * base.Mebibyte,
+						OverallWallTimeLimit: base.Duration(time.Duration(5) * time.Second),
+						ExtraWallTime:        base.Duration(0),
+						OutputLimit:          10 * base.Kibibyte,
+					},
+				},
+				ctx.Config.Runner.RuntimePath,
+				common.LiteralPersistRunner,
+			)
+			if err != nil {
+				t.Fatalf("Failed to create Input: %q", err)
+			}
+			inputRef, err := inputManager.Add(AplusB.Hash(), AplusB)
+			if err != nil {
+				t.Fatalf("Failed to open problem: %q", err)
+			}
+			defer inputRef.Release()
+
+			runtests := []runnerTestCase{
+				{
+					"py3",
+					"print(sum(map(int, input().strip().split())))",
+					big.NewRat(1, 1),
+					"AC",
+					big.NewRat(1, 1),
+					expectedResult{"", "", &RunMetadata{Verdict: "OK"}},
+					map[string]expectedResult{
+						"0":   {"1", "", &RunMetadata{Verdict: "OK"}},
+						"1.0": {"1", "", &RunMetadata{Verdict: "OK"}},
+						"1.1": {"1", "", &RunMetadata{Verdict: "OK"}},
+					},
+				},
+				{
+					"py3",
+					"print(3)",
+					big.NewRat(1, 1),
+					"PA",
+					big.NewRat(7, 10),
+					expectedResult{"", "", &RunMetadata{Verdict: "OK"}},
+					map[string]expectedResult{
+						"0":   {"1", "", &RunMetadata{Verdict: "OK"}},
+						"1.0": {"1", "", &RunMetadata{Verdict: "OK"}},
+						"1.1": {"0.6", "", &RunMetadata{Verdict: "OK"}},
+					},
+				},
+				{
+					"py3",
+					"print(2)",
+					big.NewRat(1, 1),
+					"PA",
+					big.NewRat(7, 15),
+					expectedResult{"", "", &RunMetadata{Verdict: "OK"}},
+					map[string]expectedResult{
+						"0":   {"0.6666666666666667", "", &RunMetadata{Verdict: "OK"}},
+						"1.0": {"0.6666666666666667", "", &RunMetadata{Verdict: "OK"}},
+						"1.1": {"0.4", "", &RunMetadata{Verdict: "OK"}},
+					},
+				},
+			}
+			for idx, rte := range runtests {
+				t.Run(fmt.Sprintf("%s/%d/%s %s", wrapper.name(), idx, rte.language, rte.expectedVerdict), func(t *testing.T) {
+					results, err := Grade(
+						ctx,
+						&bytes.Buffer{},
+						&common.Run{
+							AttemptID: uint64(idx),
+							Language:  rte.language,
+							InputHash: inputRef.Input.Hash(),
+							Source:    rte.source,
+							MaxScore:  rte.maxScore,
+						},
+						inputRef.Input,
+						wrapper.sandbox(&rte),
+					)
+					if err != nil {
+						t.Fatalf("Failed to run %v: %q", rte, err)
+					}
+					if results.Verdict != rte.expectedVerdict {
+						t.Errorf(
+							"results.Verdict = %q, expected %q, test %v: %v",
+							results.Verdict,
+							rte.expectedVerdict,
+							idx,
+							rte,
+						)
+					}
+					if results.Score.Cmp(rte.expectedScore) != 0 {
+						t.Errorf(
+							"results.Score = %s, expected %s",
+							results.Score.String(),
+							rte.expectedScore.String(),
+						)
+					}
+				})
+			}
+		})
+	}
+}
+
 func TestGradeLowMemOmegajail(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")

--- a/runner/validator.go
+++ b/runner/validator.go
@@ -18,12 +18,12 @@ func CalculateScore(
 	expectedOutput, contestantOutput io.Reader,
 ) (*big.Rat, *TokenMismatch, error) {
 	scanFunc := IsNonWhitespace
-	if settings.Name == "token-numeric" {
+	if settings.Name == common.ValidatorNameTokenNumeric {
 		scanFunc = IsNumeric
 	}
 
 	contestantTokenizer := NewTokenizer(contestantOutput, scanFunc)
-	if settings.Name == "literal" || settings.Name == "custom" {
+	if settings.Name == common.ValidatorNameLiteral || settings.Name == common.ValidatorNameCustom {
 		if !contestantTokenizer.Scan() {
 			return &big.Rat{}, nil, io.ErrUnexpectedEOF
 		}
@@ -62,11 +62,11 @@ func CalculateScore(
 		contestantToken := contestantTokenizer.Token()
 		correct := true
 		switch settings.Name {
-		case "token":
+		case common.ValidatorNameToken:
 			correct = tokenEquals(expectedToken.Text, contestantToken.Text)
-		case "token-caseless":
+		case common.ValidatorNameTokenCaseless:
 			correct = tokenCaselessEquals(expectedToken.Text, contestantToken.Text)
-		case "token-numeric":
+		case common.ValidatorNameTokenNumeric:
 			tolerance := common.DefaultValidatorTolerance
 			if settings.Tolerance != nil {
 				tolerance = *settings.Tolerance

--- a/runner/validator_test.go
+++ b/runner/validator_test.go
@@ -47,29 +47,29 @@ func TestValidator(t *testing.T) {
 		got, expect   string
 		settings      VS
 	}{
-		{big.NewRat(0, 1), "a", "b", VS{Name: "token"}},
-		{big.NewRat(1, 1), "a", "a", VS{Name: "token"}},
-		{big.NewRat(0, 1), "A", "a", VS{Name: "token"}},
-		{big.NewRat(1, 1), "A", "a", VS{Name: "token-caseless"}},
-		{big.NewRat(0, 1), "A", "b", VS{Name: "token-caseless"}},
-		{big.NewRat(1, 1), "11\x1f\n", "11\n", VS{Name: "token-caseless"}},
-		{big.NewRat(0, 1), "1", "2", VS{Name: "token-numeric", Tolerance: &t1}},
-		{big.NewRat(1, 1), "1", "1", VS{Name: "token-numeric", Tolerance: &t1}},
-		{big.NewRat(1, 1), "1", "1.1", VS{Name: "token-numeric", Tolerance: &t1}},
-		{big.NewRat(0, 1), "1", "1.2", VS{Name: "token-numeric", Tolerance: &t1}},
-		{big.NewRat(1, 1), "1.15", "1.20", VS{Name: "token-numeric", Tolerance: &t1}},
-		{big.NewRat(1, 1), "1.24", "1.20", VS{Name: "token-numeric", Tolerance: &t1}},
-		{big.NewRat(0, 1), "1", "x", VS{Name: "token-numeric", Tolerance: &t1}},
-		{big.NewRat(0, 1), "x", "1", VS{Name: "token-numeric", Tolerance: &t1}},
-		{big.NewRat(1, 1), "x 1", "x 1", VS{Name: "token-numeric", Tolerance: &t1}},
-		{big.NewRat(1, 1), "1", "x 1 x", VS{Name: "token-numeric", Tolerance: &t1}},
-		{big.NewRat(0, 1), "1", "-1", VS{Name: "token-numeric", Tolerance: &t1}},
-		{big.NewRat(1, 1), "0 -1", "0 -1", VS{Name: "token-numeric", Tolerance: &t1}},
-		{big.NewRat(1, 1), "1e99999999", "1e99999999", VS{Name: "token-numeric", Tolerance: &t1}},
-		{big.NewRat(1, 1), "0.000002", "0.000003", VS{Name: "token-numeric", Tolerance: &t6}},
-		{big.NewRat(0, 1), "a a", "a", VS{Name: "token"}},
-		{big.NewRat(0, 1), "a", "a a", VS{Name: "token"}},
-		{big.NewRat(1, 2), "0.5", "", VS{Name: "literal"}},
+		{big.NewRat(0, 1), "a", "b", VS{Name: common.ValidatorNameToken}},
+		{big.NewRat(1, 1), "a", "a", VS{Name: common.ValidatorNameToken}},
+		{big.NewRat(0, 1), "A", "a", VS{Name: common.ValidatorNameToken}},
+		{big.NewRat(1, 1), "A", "a", VS{Name: common.ValidatorNameTokenCaseless}},
+		{big.NewRat(0, 1), "A", "b", VS{Name: common.ValidatorNameTokenCaseless}},
+		{big.NewRat(1, 1), "11\x1f\n", "11\n", VS{Name: common.ValidatorNameTokenCaseless}},
+		{big.NewRat(0, 1), "1", "2", VS{Name: common.ValidatorNameTokenNumeric, Tolerance: &t1}},
+		{big.NewRat(1, 1), "1", "1", VS{Name: common.ValidatorNameTokenNumeric, Tolerance: &t1}},
+		{big.NewRat(1, 1), "1", "1.1", VS{Name: common.ValidatorNameTokenNumeric, Tolerance: &t1}},
+		{big.NewRat(0, 1), "1", "1.2", VS{Name: common.ValidatorNameTokenNumeric, Tolerance: &t1}},
+		{big.NewRat(1, 1), "1.15", "1.20", VS{Name: common.ValidatorNameTokenNumeric, Tolerance: &t1}},
+		{big.NewRat(1, 1), "1.24", "1.20", VS{Name: common.ValidatorNameTokenNumeric, Tolerance: &t1}},
+		{big.NewRat(0, 1), "1", "x", VS{Name: common.ValidatorNameTokenNumeric, Tolerance: &t1}},
+		{big.NewRat(0, 1), "x", "1", VS{Name: common.ValidatorNameTokenNumeric, Tolerance: &t1}},
+		{big.NewRat(1, 1), "x 1", "x 1", VS{Name: common.ValidatorNameTokenNumeric, Tolerance: &t1}},
+		{big.NewRat(1, 1), "1", "x 1 x", VS{Name: common.ValidatorNameTokenNumeric, Tolerance: &t1}},
+		{big.NewRat(0, 1), "1", "-1", VS{Name: common.ValidatorNameTokenNumeric, Tolerance: &t1}},
+		{big.NewRat(1, 1), "0 -1", "0 -1", VS{Name: common.ValidatorNameTokenNumeric, Tolerance: &t1}},
+		{big.NewRat(1, 1), "1e99999999", "1e99999999", VS{Name: common.ValidatorNameTokenNumeric, Tolerance: &t1}},
+		{big.NewRat(1, 1), "0.000002", "0.000003", VS{Name: common.ValidatorNameTokenNumeric, Tolerance: &t6}},
+		{big.NewRat(0, 1), "a a", "a", VS{Name: common.ValidatorNameToken}},
+		{big.NewRat(0, 1), "a", "a a", VS{Name: common.ValidatorNameToken}},
+		{big.NewRat(1, 2), "0.5", "", VS{Name: common.ValidatorNameLiteral}},
 	}
 	for _, vet := range validatorentries {
 		gotScore, _, err := CalculateScore(
@@ -96,9 +96,9 @@ func TestValidator(t *testing.T) {
 		settings    common.ValidatorSettings
 	}{
 		{"a", "a", common.ValidatorSettings{}},
-		{"", "", common.ValidatorSettings{Name: "literal"}},
-		{"x", "", common.ValidatorSettings{Name: "literal"}},
-		{"", "", common.ValidatorSettings{Name: "custom"}},
+		{"", "", common.ValidatorSettings{Name: common.ValidatorNameLiteral}},
+		{"x", "", common.ValidatorSettings{Name: common.ValidatorNameLiteral}},
+		{"", "", common.ValidatorSettings{Name: common.ValidatorNameCustom}},
 	}
 	for _, vet := range invalidvalidatorentries {
 		if _, _, err := CalculateScore(


### PR DESCRIPTION
This change adds the `GroupScorePolicy` field for the validator
settings. This assigns the minimum of all the individual cases' scores
multiplied by the weight of the group.