### PR TITLE
Fix typo in `group_score_policy`

### DIFF
--- a/common/literalinput.go
+++ b/common/literalinput.go
@@ -115,7 +115,7 @@ type LiteralCustomValidatorSettings struct {
 // must contain a numeric tolerance (typically a small number).
 type LiteralValidatorSettings struct {
 	Name             ValidatorName                   `json:"name"`
-	GroupScorePolicy GroupScorePolicy                `json:"groupScorePolicy,omitempty"`
+	GroupScorePolicy GroupScorePolicy                `json:"group_score_policy,omitempty"`
 	Tolerance        *float64                        `json:"tolerance,omitempty"`
 	CustomValidator  *LiteralCustomValidatorSettings `json:"custom_validator,omitempty"`
 }


### PR DESCRIPTION
This change fixes a typo in the `group_score_policy` entry in the
literal validator settings.