### PR TITLE
Update git2go to the latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,10 @@ jobs:
       - name: Install git2go
         run: |
           export GOPATH="$(go env GOPATH)"
-          go mod edit -replace "github.com/lhchavez/git2go/v32=${GOPATH}/src/github.com/lhchavez/git2go"
-          git clone --recurse-submodules https://github.com/lhchavez/git2go -b v32.0.0-prerelease.0 "${GOPATH}/src/github.com/lhchavez/git2go"
-          go get -d github.com/lhchavez/git2go/v32
-          (cd "${GOPATH}/src/github.com/lhchavez/git2go/" && ./script/build-libgit2-static.sh)
+          go mod edit -replace "github.com/libgit2/git2go/v32=${GOPATH}/src/github.com/libgit2/git2go"
+          git clone --recurse-submodules https://github.com/libgit2/git2go -b v32.0.4 "${GOPATH}/src/github.com/libgit2/git2go"
+          go get -d github.com/libgit2/git2go/v32
+          (cd "${GOPATH}/src/github.com/libgit2/git2go/" && USE_CHROMIUM_ZLIB=ON ./script/build-libgit2-static.sh)
 
       - name: Lint
         run: golint -set_exit_status ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,10 @@ jobs:
       - name: Install git2go
         run: |
           export GOPATH="$(go env GOPATH)"
-          go mod edit -replace "github.com/lhchavez/git2go/v32=${GOPATH}/src/github.com/lhchavez/git2go"
-          git clone --recurse-submodules https://github.com/lhchavez/git2go -b v32.0.0-prerelease.0 "${GOPATH}/src/github.com/lhchavez/git2go"
-          go get -d github.com/lhchavez/git2go/v32
-          (cd "${GOPATH}/src/github.com/lhchavez/git2go/" && ./script/build-libgit2-static.sh)
+          go mod edit -replace "github.com/libgit2/git2go/v32=${GOPATH}/src/github.com/libgit2/git2go"
+          git clone --recurse-submodules https://github.com/libgit2/git2go -b v32.0.4 "${GOPATH}/src/github.com/libgit2/git2go"
+          go get -d github.com/libgit2/git2go/v32
+          (cd "${GOPATH}/src/github.com/libgit2/git2go/" && USE_CHROMIUM_ZLIB=ON ./script/build-libgit2-static.sh)
 
       - name: Get dependencies
         run: go get -tags=static -t -v ./...

--- a/Dockerfile.prebuild
+++ b/Dockerfile.prebuild
@@ -6,8 +6,8 @@ FROM golang
 RUN apt-get update && apt-get install -y --no-install-recommends libgcrypt-dev libgpg-error-dev pkg-config cmake && rm -rf /var/lib/apt/lists/*
 
 # Get/build all dependencies.
-RUN go get -d github.com/lhchavez/git2go
-RUN (cd /go/src/github.com/lhchavez/git2go && git checkout v32.0.0-prerelease.0 && git submodule update --init && make install)
+RUN go get -d github.com/libgit2/git2go
+RUN (cd /go/src/github.com/libgit2/git2go && git checkout v32.0.4 && git submodule update --init && USE_CHROMIUM_ZLIB=ON make install)
 RUN go get -d github.com/mattn/go-sqlite3
 RUN go install github.com/mattn/go-sqlite3
 RUN go get github.com/go-sql-driver/mysql

--- a/cmd/omegaup-grader/ci.go
+++ b/cmd/omegaup-grader/ci.go
@@ -11,7 +11,7 @@ import (
 	"regexp"
 	"time"
 
-	git "github.com/lhchavez/git2go/v32"
+	git "github.com/libgit2/git2go/v32"
 	base "github.com/omegaup/go-base/v2"
 	"github.com/omegaup/quark/common"
 	"github.com/omegaup/quark/grader"

--- a/cmd/omegaup-grader/main.go
+++ b/cmd/omegaup-grader/main.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/coreos/go-systemd/v22/daemon"
 	_ "github.com/go-sql-driver/mysql"
-	git "github.com/lhchavez/git2go/v32"
+	git "github.com/libgit2/git2go/v32"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/omegaup/quark/common"
 	"github.com/omegaup/quark/grader"

--- a/common/problemfiles.go
+++ b/common/problemfiles.go
@@ -14,7 +14,7 @@ import (
 	"sort"
 	"strings"
 
-	git "github.com/lhchavez/git2go/v32"
+	git "github.com/libgit2/git2go/v32"
 	"github.com/pkg/errors"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -4,17 +4,26 @@ go 1.17
 
 require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.1.0
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/go-sql-driver/mysql v1.5.0
+	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/gorilla/websocket v1.4.2
 	github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac
-	github.com/lhchavez/git2go/v32 v32.0.0-prerelease.0
+	github.com/libgit2/git2go/v32 v32.0.4
+	github.com/mattn/go-colorable v0.1.4 // indirect
+	github.com/mattn/go-isatty v0.0.10 // indirect
 	github.com/mattn/go-sqlite3 v1.14.8
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/omegaup/go-base/v2 v2.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.8.0
+	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.15.0 // indirect
+	github.com/prometheus/procfs v0.2.0 // indirect
 	github.com/shirou/gopsutil v3.20.11+incompatible
 	github.com/vincent-petithory/dataurl v0.0.0-20191104211930-d1553a71de50
 	golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9 // indirect
@@ -22,16 +31,4 @@ require (
 	golang.org/x/sys v0.0.0-20201214095126-aec9a390925b // indirect
 	golang.org/x/text v0.3.4 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
-)
-
-require (
-	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cespare/xxhash/v2 v2.1.1 // indirect
-	github.com/go-stack/stack v1.8.0 // indirect
-	github.com/golang/protobuf v1.4.3 // indirect
-	github.com/mattn/go-colorable v0.1.4 // indirect
-	github.com/mattn/go-isatty v0.0.10 // indirect
-	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
-	github.com/prometheus/client_model v0.2.0 // indirect
-	github.com/prometheus/procfs v0.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,8 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/lhchavez/git2go/v32 v32.0.0-prerelease.0 h1:WulJqhctwHAenw8sNRWqJ1HVs3i97yjLXQF9Yjm58ME=
-github.com/lhchavez/git2go/v32 v32.0.0-prerelease.0/go.mod h1:0iSqM2vxVO1dfqzpi4eMzlp2mtjiMQ4S1/z89H2IIb8=
+github.com/libgit2/git2go/v32 v32.0.4 h1:qK2yWGh88K2Gh76E1+vUEsjKDfOAq0J2THKaoaFIPbA=
+github.com/libgit2/git2go/v32 v32.0.4/go.mod h1:FAA2ePV5PlLjw1ccncFIvu2v8hJSZVN5IzEn4lo/vwo=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=

--- a/grader/grader_test.go
+++ b/grader/grader_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	git "github.com/lhchavez/git2go/v32"
+	git "github.com/libgit2/git2go/v32"
 )
 
 const (

--- a/grader/input.go
+++ b/grader/input.go
@@ -14,7 +14,7 @@ import (
 	"strconv"
 	"strings"
 
-	git "github.com/lhchavez/git2go/v32"
+	git "github.com/libgit2/git2go/v32"
 	"github.com/omegaup/quark/common"
 	"github.com/pkg/errors"
 )


### PR DESCRIPTION
Now that libgit2 v1.2.0 has been released, we no longer need to have a
fork (for now). #minor