### PR TITLE
Update go-base to the lastest and greatest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/mattn/go-isatty v0.0.10 // indirect
 	github.com/mattn/go-sqlite3 v1.14.8
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
-	github.com/omegaup/go-base/v2 v2.2.0
+	github.com/omegaup/go-base/v2 v2.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.8.0
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -216,6 +216,8 @@ github.com/omegaup/go-base/v2 v2.1.0 h1:pehTzNMArOQrVBOa2oLhZDIhWSU80phIHrBi+gL4
 github.com/omegaup/go-base/v2 v2.1.0/go.mod h1:DotC1e60GE6S+iqe9RyusanekwK/eyU/YL3so86X3SA=
 github.com/omegaup/go-base/v2 v2.2.0 h1:bb4PrDOlJ+v17QHblBN3QGNTWoRhtgOW+k7x9q2L9Ik=
 github.com/omegaup/go-base/v2 v2.2.0/go.mod h1:DotC1e60GE6S+iqe9RyusanekwK/eyU/YL3so86X3SA=
+github.com/omegaup/go-base/v2 v2.3.0 h1:u5juOm0O96ZeuJu3xYSwvyGtstIkCEDT/F016gzSfow=
+github.com/omegaup/go-base/v2 v2.3.0/go.mod h1:DotC1e60GE6S+iqe9RyusanekwK/eyU/YL3so86X3SA=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=


### PR DESCRIPTION
This should make it possible for downstream modules to import the
newrelic tracing module. #minor