### PR TITLE
CI: Allow checking input validators against known invalid cases

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "go.buildTags": "static"
+}

--- a/runner/ci/ci_test.go
+++ b/runner/ci/ci_test.go
@@ -419,7 +419,104 @@ func TestNewRunConfig(t *testing.T) {
 					Validator: &common.LiteralValidatorSettings{},
 				},
 			},
-			"\"tests/validator.py\" in \":memory:\": file does not exist",
+			"",
+		},
+		{
+			"input validator with invalid cases",
+			common.NewProblemFilesFromMap(
+				map[string]string{
+					"tests/tests.json": `{
+						"inputs": {
+							"filename": "validator.py"
+						}
+					}`,
+					"tests/validator.py":        "print(3)",
+					"tests/invalid-cases/0.in":  "input",
+					"tests/invalid-cases/0.out": "output",
+					"settings.json":             "{}",
+				},
+				":memory:",
+			),
+			false,
+			&RunConfig{
+				TestsSettings: common.TestsSettings{
+					InputsValidator: &common.InputsValidatorSettings{Filename: "validator.py"},
+				},
+				TestConfigs: []*TestConfig{
+					{
+						Test: &ReportTest{
+							Index:                  0,
+							Type:                   "inputs",
+							Filename:               "validator.py",
+							InputsValidatorSetting: &common.InputsValidatorSettings{Filename: "validator.py"},
+						},
+						Solution: SolutionConfig{
+							Source:   CopyStdinToStdoutSource,
+							Language: "cpp11",
+						},
+						Input: &common.LiteralInput{
+							Cases: map[string]*common.LiteralCaseSettings{},
+							Validator: &common.LiteralValidatorSettings{
+								Name: common.ValidatorNameCustom,
+								CustomValidator: &common.LiteralCustomValidatorSettings{
+									Source:   "print(3)",
+									Language: "py",
+								},
+							},
+						},
+					},
+					{
+						Test: &ReportTest{
+							Index:                  1,
+							Type:                   "invalid-inputs",
+							Filename:               "validator.py",
+							InputsValidatorSetting: &common.InputsValidatorSettings{Filename: "validator.py"},
+							SolutionSetting:        &common.SolutionSettings{Verdict: "WA"},
+						},
+						Solution: SolutionConfig{
+							Source:   CopyStdinToStdoutSource,
+							Language: "cpp11",
+						},
+						Input: &common.LiteralInput{
+							Cases: map[string]*common.LiteralCaseSettings{
+								"0": {Input: "input", ExpectedOutput: "output", Weight: big.NewRat(1, 1)},
+							},
+							Validator: &common.LiteralValidatorSettings{
+								Name: common.ValidatorNameCustom,
+								CustomValidator: &common.LiteralCustomValidatorSettings{
+									Source:   "print(3)",
+									Language: "py",
+								},
+							},
+						},
+					},
+				},
+				Input: &common.LiteralInput{
+					Cases:     map[string]*common.LiteralCaseSettings{},
+					Limits:    &common.DefaultLimits,
+					Validator: &common.LiteralValidatorSettings{},
+				},
+			},
+			"",
+		},
+		{
+			"input validator with invalid cases, missing output",
+			common.NewProblemFilesFromMap(
+				map[string]string{
+					"tests/tests.json": `{
+						"inputs": {
+							"filename": "validator.py"
+						}
+					}`,
+					"tests/validator.py":       "print(3)",
+					"tests/invalid-cases/0.in": "input",
+					"settings.json":            "{}",
+				},
+				":memory:",
+			),
+			false,
+			nil,
+			"open \"tests/invalid-cases/0.out\"",
 		},
 		{
 			"output generator, multiple files",


### PR DESCRIPTION
Feature parity with polygon: https://ali-ibrahim137.github.io/competitive/programming/2020/09/27/polygon-codeforces.html (ctrl+f: invalid)

The idea is that we should also be able to test _input validators_ themselves, by optionally having a set of _known_ invalid cases that the validator should reject.

(Also adds a .vscode file to the project so building/testing works with the official golang extension)