### PR TITLE
Try harder to keep the connection alive

### DIFF
--- a/cmd/omegaup-grader/runner_handler.go
+++ b/cmd/omegaup-grader/runner_handler.go
@@ -65,7 +65,9 @@ func processRun(
 			},
 		)
 
-		if part.FileName() == "details.json" {
+		if part.FileName() == ".keepalive" {
+			// Do nothing, this is only here to keep the connection alive.
+		} else if part.FileName() == "details.json" {
 			var result runner.RunResult
 			decoder := json.NewDecoder(part)
 			decoder.UseNumber()


### PR DESCRIPTION
This change makes it such that the runners will always be sending stuff
over the network every 15s to minimize the chance of timing out and
being forcefully disconnected.

Fixes: https://github.com/omegaup/omegaup/issues/6274