### PR TITLE
Add support for group-score-policy; rekey maxScore

### DIFF
--- a/common/problemsettings.go
+++ b/common/problemsettings.go
@@ -271,7 +271,7 @@ type InputsValidatorSettings struct {
 type TestsSettings struct {
 	Solutions        []SolutionSettings       `json:"solutions"`
 	InputsValidator  *InputsValidatorSettings `json:"inputs,omitempty"`
-	ExpectedMaxScore *base.Rat                `json:"maxScore,omitempty"`
+	ExpectedMaxScore *base.Rat                `json:"max_score,omitempty"`
 }
 
 var (

--- a/runner/ci/ci.go
+++ b/runner/ci/ci.go
@@ -532,8 +532,9 @@ func NewRunConfig(files common.ProblemFiles, generateOutputFiles bool) (*RunConf
 
 	// Validator
 	config.Input.Validator = &common.LiteralValidatorSettings{
-		Name:      problemSettings.Validator.Name,
-		Tolerance: problemSettings.Validator.Tolerance,
+		Name:             problemSettings.Validator.Name,
+		Tolerance:        problemSettings.Validator.Tolerance,
+		GroupScorePolicy: problemSettings.Validator.GroupScorePolicy,
 	}
 	if problemSettings.Validator.Name == common.ValidatorNameCustom {
 		if problemSettings.Validator.Lang == nil {

--- a/runner/ci/ci_test.go
+++ b/runner/ci/ci_test.go
@@ -880,6 +880,33 @@ func TestNewRunConfig(t *testing.T) {
 			"",
 		},
 		{
+			"group score policy",
+			common.NewProblemFilesFromMap(
+				map[string]string{
+					"settings.json": `{
+						"validator": {
+							"GroupScorePolicy": "min"
+						}
+					}`,
+					"tests/tests.json": `{
+					}`,
+				},
+				":memory:",
+			),
+			false,
+			&RunConfig{
+				TestsSettings: common.TestsSettings{},
+				Input: &common.LiteralInput{
+					Cases:  map[string]*common.LiteralCaseSettings{},
+					Limits: &common.DefaultLimits,
+					Validator: &common.LiteralValidatorSettings{
+						GroupScorePolicy: common.GroupScorePolicyMin,
+					},
+				},
+			},
+			"",
+		},
+		{
 			"expected max score",
 			common.NewProblemFilesFromMap(
 				map[string]string{
@@ -889,7 +916,7 @@ func TestNewRunConfig(t *testing.T) {
 					"cases/1.out": "3",
 					"testplan":    "0 50\n1 50\n",
 					"tests/tests.json": `{
-						"maxScore": 100
+						"max_score": 100
 					}`,
 					"settings.json": "{}",
 				},
@@ -929,7 +956,7 @@ func TestNewRunConfig(t *testing.T) {
 					"cases/1.out": "3",
 					"testplan":    "0 50\n1 49\n",
 					"tests/tests.json": `{
-						"maxScore": 100
+						"max_score": 100
 					}`,
 					"settings.json": "{}",
 				},

--- a/runner/ci/ci_test.go
+++ b/runner/ci/ci_test.go
@@ -880,6 +880,39 @@ func TestNewRunConfig(t *testing.T) {
 			"",
 		},
 		{
+			"custom validator",
+			common.NewProblemFilesFromMap(
+				map[string]string{
+					"settings.json": `{
+						"validator": {
+							"name": "custom",
+							"lang": "py"
+						}
+					}`,
+					"tests/tests.json": `{
+					}`,
+					"validator.py": "print(1)",
+				},
+				":memory:",
+			),
+			false,
+			&RunConfig{
+				TestsSettings: common.TestsSettings{},
+				Input: &common.LiteralInput{
+					Cases:  map[string]*common.LiteralCaseSettings{},
+					Limits: &common.DefaultLimits,
+					Validator: &common.LiteralValidatorSettings{
+						Name: "custom",
+						CustomValidator: &common.LiteralCustomValidatorSettings{
+							Source:   "print(1)",
+							Language: "py",
+						},
+					},
+				},
+			},
+			"",
+		},
+		{
 			"group score policy",
 			common.NewProblemFilesFromMap(
 				map[string]string{


### PR DESCRIPTION
Faltaba pasar el GroupScorePolicy a los CI runs.

También por consistencia cambia `maxScore` por `max_score`; el resto de las llaves de ese json son con `snake_case` (somos los únicos usuarios: prometo no hacer breaking changes tan horribles si hay otra gente usando las cosas 😬😇)