### PR TITLE
Trim whitespace on stderr validation

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1365,7 +1365,8 @@ func Grade(
 							)
 							return err
 						}
-						if !strings.Contains(string(validatorStderr), string(expectedStderr)) {
+						expectedString := strings.TrimSpace(string(expectedStderr))
+						if !strings.Contains(string(validatorStderr), expectedString) {
 							ctx.Log.Warn(
 								"Validator stderr did not contain expected string",
 								map[string]interface{}{

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -1675,9 +1675,9 @@ func TestGradeWithCustomValidatorExpectedOutput(t *testing.T) {
 					AplusB, err := common.NewLiteralInputFactory(
 						&common.LiteralInput{
 							Cases: map[string]*common.LiteralCaseSettings{
-								"0":   {Input: "1 2", ExpectedOutput: "3", ExpectedValidatorStderr: "expected", Weight: big.NewRat(1, 1)},
-								"1.0": {Input: "1 2", ExpectedOutput: "3", ExpectedValidatorStderr: "expected", Weight: big.NewRat(1, 1)},
-								"1.1": {Input: "2 3", ExpectedOutput: "5", ExpectedValidatorStderr: "expected", Weight: big.NewRat(2, 1)},
+								"0":   {Input: "1 2", ExpectedOutput: "3", ExpectedValidatorStderr: "expected\n", Weight: big.NewRat(1, 1)},
+								"1.0": {Input: "1 2", ExpectedOutput: "3", ExpectedValidatorStderr: "expected\n", Weight: big.NewRat(1, 1)},
+								"1.1": {Input: "2 3", ExpectedOutput: "5", ExpectedValidatorStderr: "expected\n", Weight: big.NewRat(2, 1)},
 							},
 							Limits: &common.DefaultLimits,
 							Validator: &common.LiteralValidatorSettings{


### PR DESCRIPTION
En particular, los newlines al final de los archivos estaban haciendo tronar algunos tests porque el string que tenía esperado era en medio de una línea y pues fallaba porque no encontraba el newline .-.

https://github.com/omegaup/ofmi-2022/runs/4884915041?check_suite_focus=true#step:10:137
El string en cuestión era el que estaba en medio de las comillas: `"aa" [REDACTED] "aa"`.