### PR TITLE
Always updating the zip with files

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -588,6 +588,25 @@ func Grade(
 		},
 	)
 
+	generatedFiles := make([]string, 0)
+	defer func() {
+		defer ctx.Transaction.StartSegment("upload").End()
+		if err := uploadFiles(
+			ctx,
+			filesWriter,
+			runRoot,
+			input,
+			generatedFiles,
+		); err != nil {
+			ctx.Log.Error(
+				"uploadFiles failed",
+				map[string]interface{}{
+					"err": err,
+				},
+			)
+		}
+	}()
+
 	var binaries []*binary
 	var outputOnlyFiles map[string]outputOnlyFile
 	runResult.CompileMeta = make(map[string]RunMetadata)
@@ -870,8 +889,6 @@ func Grade(
 			},
 		)
 	}
-
-	generatedFiles := make([]string, 0)
 
 	compileSegment := ctx.Transaction.StartSegment("compile")
 	for _, b := range binaries {
@@ -1400,22 +1417,6 @@ func Grade(
 			"score":   runResult.Score,
 		},
 	)
-	defer ctx.Transaction.StartSegment("upload").End()
-	if err := uploadFiles(
-		ctx,
-		filesWriter,
-		runRoot,
-		input,
-		generatedFiles,
-	); err != nil {
-		ctx.Log.Error(
-			"uploadFiles failed",
-			map[string]interface{}{
-				"err": err,
-			},
-		)
-		return runResult, err
-	}
 
 	return runResult, nil
 }


### PR DESCRIPTION
Previously, when a compiler error happened, the generated .zip file had
nothing in it (in fact, it was an empty file).