### PR TITLE
Make the sandbox invocation log actually work

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -186,6 +186,8 @@ github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -20,6 +20,7 @@ import (
 
 	base "github.com/omegaup/go-base/v3"
 	"github.com/omegaup/quark/common"
+
 	"github.com/vincent-petithory/dataurl"
 )
 

--- a/runner/sandbox.go
+++ b/runner/sandbox.go
@@ -15,6 +15,8 @@ import (
 
 	base "github.com/omegaup/go-base/v3"
 	"github.com/omegaup/quark/common"
+
+	"github.com/kballard/go-shellquote"
 	"github.com/pkg/errors"
 )
 
@@ -365,7 +367,7 @@ func invokeOmegajail(ctx *common.Context, omegajailRoot string, omegajailParams 
 	ctx.Log.Debug(
 		"invoking",
 		map[string]interface{}{
-			"params": omegajailFullParams,
+			"params": shellquote.Join(omegajailFullParams...),
 		},
 	)
 	cmd := exec.Command(omegajailFullParams[0], omegajailParams...)


### PR DESCRIPTION
This change makes the omegajail invocation log display the correctly
escaped string.