### PR TITLE
Bump omegajail to v3.9.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,12 @@ FROM docker.pkg.github.com/omegaup/omegajail/omegajail-builder-rootfs-runtime:v3
 
 FROM base AS builder
 
+# Dependencies for packages.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install karel.js in a builder container to avoid leaving a lot of trash in
 # the /root directory.
 RUN mkdir /tmp/karel && \
@@ -10,9 +16,15 @@ RUN mkdir /tmp/karel && \
     mv /tmp/karel/node_modules/* /opt/nodejs/lib/node_modules/ && \
     rm -rf /tmp/karel
 
+# Install a newer version of the omegajail binary.
+RUN rm -rf /var/lib/omegajail && \
+    curl -sSL https://github.com/omegaup/omegajail/releases/download/v3.9.1/omegajail-focal-distrib-x86_64.tar.xz | tar xJ -C /
+
 FROM base
 
 COPY --from=builder /opt/nodejs/lib/node_modules/ /opt/nodejs/lib/node_modules/
+RUN rm -rf /var/lib/omegajail
+COPY --from=builder /var/lib/omegajail/ /var/lib/omegajail/
 RUN mkdir -p /etc/omegaup/runner /var/lib/omegaup
 RUN chmod 777 /var/lib/omegaup
 COPY bin/omegaup-runner /usr/bin/omegaup-runner


### PR DESCRIPTION
This change bumps omegajail (the binary, not the rootfs) to v3.9.1 so
that it can have the `--allow-sigsys-fallback` flag.