### PR TITLE
Allow omegajail to use the `SIGSYS` fallback when in CI mode

### DIFF
--- a/cmd/omegaup-runner/main.go
+++ b/cmd/omegaup-runner/main.go
@@ -702,7 +702,12 @@ func main() {
 			)
 			os.Exit(1)
 		}
-		sandbox = runner.NewOmegajailSandbox(omegajailRoot)
+		oj := runner.NewOmegajailSandbox(omegajailRoot)
+		if *oneshot == "ci" {
+			// Allow sigsys to use the fallback detector when running in CI.
+			oj.AllowSigsysFallback = true
+		}
+		sandbox = oj
 	}
 
 	if isOneShotMode() {


### PR DESCRIPTION
This is needed for the CI mode to work well locally in older (pre-5.13)
Linux kernels, like the ones in WSL or some versions of Docker-in-Mac.