### PR TITLE
Make the release steps also run Go 1.19

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.19
         id: go
 
       - name: Install git2go


### PR DESCRIPTION
Not doing this will cause failures to compile things.