### PR TITLE
Add a way to export runners

### DIFF
--- a/cmd/omegaup-grader/runner_handler.go
+++ b/cmd/omegaup-grader/runner_handler.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/omegaup/quark/common"
@@ -185,6 +186,15 @@ func registerRunnerHandlers(
 				"client": runnerName,
 			},
 		)
+
+		// Add the runner to the list of known runners.
+		m, ok := ctx.Metrics.(*prometheusMetrics)
+		if ok {
+			colon := strings.LastIndex(r.RemoteAddr, ":")
+			if colon != -1 {
+				m.RunnerObserve(r.RemoteAddr[:colon])
+			}
+		}
 
 		runCtx, _, ok := runs.GetRun(
 			runnerName,


### PR DESCRIPTION
This change allows prometheus to do discovery of runners without needing to do Azure service discovery.