### PR TITLE
Make the runner publish its own public IP when requesting

### DIFF
--- a/cmd/omegaup-runner/main.go
+++ b/cmd/omegaup-runner/main.go
@@ -91,6 +91,30 @@ func loadContext() error {
 	if err != nil {
 		return err
 	}
+
+	res, err := http.Get("https://ifconfig.me")
+	if err != nil {
+		ctx.Log.Error(
+			"Failed to get public IP",
+			map[string]any{
+				"err": err,
+			},
+		)
+	} else {
+		ip, err := io.ReadAll(res.Body)
+		res.Body.Close()
+		if err != nil {
+			ctx.Log.Error(
+				"Failed to read public IP",
+				map[string]any{
+					"err": err,
+				},
+			)
+		} else {
+			ctx.Config.Runner.PublicIP = strings.TrimSpace(string(ip))
+		}
+	}
+
 	globalContext.Store(ctx)
 	return nil
 }

--- a/cmd/omegaup-runner/service.go
+++ b/cmd/omegaup-runner/service.go
@@ -184,6 +184,9 @@ func processRun(
 	if parentCtx.Config.Runner.Hostname != "" {
 		req.Header.Add("OmegaUp-Runner-Name", parentCtx.Config.Runner.Hostname)
 	}
+	if parentCtx.Config.Runner.PublicIP != "" {
+		req.Header.Add("OmegaUp-Runner-PublicIP", parentCtx.Config.Runner.PublicIP)
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return err

--- a/common/context.go
+++ b/common/context.go
@@ -86,6 +86,7 @@ type TLSConfig struct {
 // RunnerConfig represents the configuration for the Runner.
 type RunnerConfig struct {
 	Hostname           string
+	PublicIP           string
 	GraderURL          string
 	RuntimePath        string
 	CompileTimeLimit   base.Duration


### PR DESCRIPTION
This allows the grader to correctly represent the runner's public server.