### PR TITLE
Publish the self-reported runner public IP

### DIFF
--- a/cmd/omegaup-grader/runner_handler.go
+++ b/cmd/omegaup-grader/runner_handler.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/omegaup/quark/common"
@@ -190,9 +189,9 @@ func registerRunnerHandlers(
 		// Add the runner to the list of known runners.
 		m, ok := ctx.Metrics.(*prometheusMetrics)
 		if ok {
-			colon := strings.LastIndex(r.RemoteAddr, ":")
-			if colon != -1 {
-				m.RunnerObserve(r.RemoteAddr[:colon] + ":6060")
+			remoteAddr := r.Header.Get("OmegaUp-Runner-PublicIP")
+			if remoteAddr != "" {
+				m.RunnerObserve(remoteAddr + ":6060")
 			}
 		}
 


### PR DESCRIPTION
The remote address as reported by `r.RemoteAddr` is not useful because it's the ingress internal address. This change now uses the self-reported public IP address from the runner.