### PR TITLE
Finish the `omegaup-submissions` migration

### DIFF
--- a/grader/artifacts.go
+++ b/grader/artifacts.go
@@ -1,7 +1,6 @@
 package grader
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -244,8 +243,8 @@ func (a *SubmissionsArtifacts) GetSource(ctx *common.Context, guid string) (stri
 	r, err := getArtifact(
 		ctx,
 		a.s3c,
-		"omegaup-backup",
-		path.Join("omegaup", submissionKey),
+		"omegaup-submissions",
+		guid,
 		path.Join(ctx.Config.Grader.V1.RuntimePath, submissionKey),
 	)
 	if err != nil {
@@ -261,37 +260,19 @@ func (a *SubmissionsArtifacts) GetSource(ctx *common.Context, guid string) (stri
 
 // PutSource writes the source of the submission to the filesystem (and maybe to S3).
 func (a *SubmissionsArtifacts) PutSource(ctx *common.Context, guid string, r io.Reader) error {
-	var buf bytes.Buffer
-	_, err := io.Copy(&buf, r)
-	if err != nil {
-		return fmt.Errorf("read: %w", err)
-	}
-
 	backupSubmissionKey := path.Join(
 		"submissions",
 		guid[:2],
 		guid[2:],
 	)
-	err = putArtifact(
-		ctx,
-		a.s3c,
-		"omegaup-backup",
-		path.Join("omegaup", backupSubmissionKey),
-		path.Join(ctx.Config.Grader.V1.RuntimePath, backupSubmissionKey),
-		bytes.NewReader(buf.Bytes()),
-	)
-	if err != nil {
-		return fmt.Errorf("put omegaup-backup: %w", err)
-	}
 
-	// TODO: leave just this version once the migration is done.
 	return putArtifact(
 		ctx,
 		a.s3c,
 		"omegaup-submissions",
 		guid,
 		path.Join(ctx.Config.Grader.V1.RuntimePath, backupSubmissionKey),
-		bytes.NewReader(buf.Bytes()),
+		r,
 	)
 }
 


### PR DESCRIPTION
Now that we save all the submissions in this bucket, we don't need to keep the old one around for anything.