### PR TITLE
Turned on the flag disable-sandboxing

### DIFF
--- a/runner/sandbox.go
+++ b/runner/sandbox.go
@@ -192,6 +192,7 @@ func (o *OmegajailSandbox) Compile(
 		"--root", o.omegajailRoot,
 		"--compile", lang,
 		"--compile-target", target,
+		"--disable-sandboxing", strconv.FormatBool(true),
 	}
 	for _, inputFile := range inputFiles {
 		if !strings.HasPrefix(inputFile, chdir) {
@@ -329,6 +330,7 @@ func (o *OmegajailSandbox) Run(
 		"--root", o.omegajailRoot,
 		"--run", lang,
 		"--run-target", target,
+		"--disable-sandboxing", strconv.FormatBool(true),
 	}
 	for path, mountTarget := range extraMountPoints {
 		params = append(


### PR DESCRIPTION
Turning on the flag `--disable-sandboxing` in order to allow the grader evaluate the submissions