### PR TITLE
Using the correct variable to invoke omegajail

### DIFF
--- a/runner/sandbox.go
+++ b/runner/sandbox.go
@@ -384,7 +384,7 @@ func (o *OmegajailSandbox) invokeOmegajail(ctx *common.Context, omegajailParams 
 			"params": shellquote.Join(omegajailFullParams...),
 		},
 	)
-	cmd := exec.Command(omegajailFullParams[0], omegajailParams...)
+	cmd := exec.Command(omegajailFullParams[0], omegajailFullParams...)
 	omegajailErrorFile := errorFile + ".omegajail"
 	omegajailErrorFd, err := os.Create(omegajailErrorFile)
 	if err != nil {


### PR DESCRIPTION
Previously we were using `omegajailParams`, which don't have the extra flags, but were logging `omegajailFullParams`!

Now we use and log the same one.