### PR TITLE
Fix the omegajail invocation

### DIFF
--- a/runner/sandbox.go
+++ b/runner/sandbox.go
@@ -384,7 +384,7 @@ func (o *OmegajailSandbox) invokeOmegajail(ctx *common.Context, omegajailParams 
 			"params": shellquote.Join(omegajailFullParams...),
 		},
 	)
-	cmd := exec.Command(omegajailFullParams[0], omegajailFullParams...)
+	cmd := exec.Command(omegajailFullParams[0], omegajailFullParams[1:]...)
 	omegajailErrorFile := errorFile + ".omegajail"
 	omegajailErrorFd, err := os.Create(omegajailErrorFile)
 	if err != nil {


### PR DESCRIPTION
Turns out that `exec.Command` doesn't like having the first arg there.