### PR TITLE
libinteractive bump

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -12,7 +12,7 @@ RUN apt-get update -y && \
     apt-get autoremove -y && \
     apt-get clean
 
-RUN curl -sL https://github.com/omegaup/libinteractive/releases/download/v2.0.27/libinteractive.jar \
+RUN curl -sL https://github.com/omegaup/libinteractive/releases/download/v2.0.29/libinteractive.jar \
         -o /usr/share/java/libinteractive.jar && \
     useradd --create-home --shell=/bin/bash ubuntu && \
     mkdir -p /etc/omegaup/gitserver /var/log/omegaup /var/lib/omegaup/problems.git && \


### PR DESCRIPTION
This change now allows compilation and testing in M1 macOS.