### PR TITLE
Bump omegajail to v3.10.2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir /tmp/karel && \
 
 # Install a newer version of the omegajail binary.
 RUN rm -rf /var/lib/omegajail && \
-    curl -sSL https://github.com/omegaup/omegajail/releases/download/v3.10.1/omegajail-focal-distrib-x86_64.tar.xz | tar xJ -C / && \
+    curl -sSL https://github.com/omegaup/omegajail/releases/download/v3.10.2/omegajail-focal-distrib-x86_64.tar.xz | tar xJ -C / && \
     curl -sL https://github.com/omegaup/libinteractive/releases/download/v2.0.29/libinteractive.jar \
         -o /usr/share/java/libinteractive.jar
 


### PR DESCRIPTION
This change bumps omegajail so that we can finally run interactive problems again, since they require compiling C++ and assembly files in the same commandline invocation.