### PR TITLE
Allow running libinteractive problems without sandboxing

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ RUN mkdir /tmp/karel && \
 # Install a newer version of the omegajail binary.
 RUN rm -rf /var/lib/omegajail && \
     curl -sSL https://github.com/omegaup/omegajail/releases/download/v3.10.2/omegajail-focal-distrib-x86_64.tar.xz | tar xJ -C / && \
-    curl -sL https://github.com/omegaup/libinteractive/releases/download/v2.0.29/libinteractive.jar \
+    curl -sL https://github.com/omegaup/libinteractive/releases/download/v2.0.30/libinteractive.jar \
         -o /usr/share/java/libinteractive.jar
 
 FROM base


### PR DESCRIPTION
Libinteractive problems required bind-mounting, but that's not enabled without a sandbox.

This change falls back to symlinking when the sandboxing is disabled.