### PR TITLE
Bump omegajail version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir /tmp/karel && \
 
 # Install a newer version of the omegajail binary.
 RUN rm -rf /var/lib/omegajail && \
-    curl -sSL https://github.com/omegaup/omegajail/releases/download/v3.10.2/omegajail-focal-distrib-x86_64.tar.xz | tar xJ -C / && \
+    curl -sSL https://github.com/omegaup/omegajail/releases/download/v3.10.3/omegajail-focal-distrib-x86_64.tar.xz | tar xJ -C / && \
     curl -sL https://github.com/omegaup/libinteractive/releases/download/v2.0.30/libinteractive.jar \
         -o /usr/share/java/libinteractive.jar
 


### PR DESCRIPTION
This change bumps the omegajail version so that it can skip setting up the seccomp sandbox when needed.