### PR TITLE
[runner] Fix IP getting

### DIFF
--- a/cmd/omegaup-runner/main.go
+++ b/cmd/omegaup-runner/main.go
@@ -93,7 +93,7 @@ func loadContext() error {
 		return err
 	}
 
-	res, err := http.Get("https://ifconfig.me")
+	res, err := http.Get("https://ifconfig.me/ip")
 	if err != nil {
 		ctx.Log.Error(
 			"Failed to get public IP",


### PR DESCRIPTION
ifconfig.me changed their API. Now they need `/ip` to get the IP from Golang.