### PR TITLE
(fix) wrong queue delay calculation

### DIFF
--- a/grader/queue.go
+++ b/grader/queue.go
@@ -660,6 +660,12 @@ func (queue *Queue) enqueue(runCtx *RunContext, priority QueuePriority) bool {
 	select {
 	case queue.runs[priority] <- runCtx:
 		queue.ready <- struct{}{}
+		runCtx.RunInfo.QueueTime = time.Now()
+		queue.queueManager.AddEvent(&QueueEvent{
+			Delta:    time.Now().Sub(runCtx.RunInfo.CreationTime),
+			Priority: priority,
+			Type:     QueueEventTypeQueueAdded,
+		})
 		return true
 	default:
 		// There is no space left in the queue.


### PR DESCRIPTION
The `Queue.enqueue()` function is supposed to add a "run" (a task to be processed) to the queue. But in the old code, after adding the run, it does not record the time when the run was added, and it does not send an event to say "a run was added to the queue." This is different from the `enqueueBlocking()` function, which does both.

Because of this, when the system later tries to calculate how long a run waited in the queue, it might use a zero or missing time, which makes the wait time metrics wrong.

To fix this, enqueue() should:

- set `runCtx.RunInfo.QueueTime = time.Now()`
- emit `QueueEventTypeQueueAdded`
- use the `priority` parameter for the event priority 

Fixes: #142 